### PR TITLE
Fix random test failures caused by RedMica::VERSION autoloading

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -9,6 +9,8 @@ IGNORE_LIST = [
 
 class RedmineInflector < Zeitwerk::Inflector
   def camelize(basename, abspath)
+    return 'VERSION' if abspath.match?('redmica\/version.rb\z')
+
     abspath.match?('redmine\/version.rb\z') ? 'VERSION' : super
   end
 end
@@ -16,6 +18,7 @@ end
 Rails.autoloaders.each do |loader|
   loader.inflector = RedmineInflector.new
   loader.inflector.inflect(
+    'redmica' => 'RedMica',
     'html' => 'HTML',
     'csv' => 'CSV',
     'pdf' => 'PDF',

--- a/lib/redmica/version.rb
+++ b/lib/redmica/version.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RedMica
+  module VERSION
+    MAJOR = 3
+    MINOR = 1
+    TINY  = 2
+
+    BRANCH = 'devel'
+
+    # Retrieves the revision from the working copy
+    def self.revision
+      nil
+    end
+
+    REVISION = self.revision
+    ARRAY    = [MAJOR, MINOR, TINY, BRANCH, REVISION].compact
+    STRING   = ARRAY.join('.')
+
+    def self.to_a; ARRAY  end
+    def self.to_s; STRING end
+  end
+end

--- a/lib/redmine/version.rb
+++ b/lib/redmine/version.rb
@@ -44,25 +44,3 @@ module Redmine
     def self.to_s; STRING end
   end
 end
-
-module RedMica
-  module VERSION
-    MAJOR = 3
-    MINOR = 1
-    TINY  = 2
-
-    BRANCH = 'devel'
-
-    # Retrieves the revision from the working copy
-    def self.revision
-      nil
-    end
-
-    REVISION = self.revision
-    ARRAY    = [MAJOR, MINOR, TINY, BRANCH, REVISION].compact
-    STRING   = ARRAY.join('.')
-
-    def self.to_a; ARRAY  end
-    def self.to_s; STRING end
-  end
-end


### PR DESCRIPTION
This pull request addresses random failures in `test/unit/lib/redmine/info_test.rb` caused by Zeitwerk's inability to locate the `RedMica::VERSION` module. These failures include errors such as:

```
NameError: uninitialized constant #<Class:Redmine::Info>::RedMica
```
https://github.com/redmica/redmica/actions/runs/12663371745/job/35289850425

The root cause is that `RedMica::VERSION` was defined in `lib/redmine/version.rb`, which does not comply with Zeitwerk's standard autoloading conventions.

This fix updates the implementation of `RedMica::VERSION` to follow Zeitwerk's rules, ensuring proper autoloading and eliminating these random test failures.

CI has successfully passed after applying this fix. For details, see [CI results](https://github.com/hidakatsuya/redmica/actions/runs/12785528262).
