### PR TITLE
Drop empty commits in sync-redmine workflow

### DIFF
--- a/.github/workflows/sync-redmine.yml
+++ b/.github/workflows/sync-redmine.yml
@@ -123,7 +123,7 @@ jobs:
           git switch ${REDMICA_BRANCH}
 
           # Apply the Redmine patches
-          git am --keep-cr ${GITHUB_WORKSPACE}/redmine/*.patch --exclude=doc/CHANGELOG
+          git am --keep-cr --empty=drop ${GITHUB_WORKSPACE}/redmine/*.patch --exclude=doc/CHANGELOG
           git log --oneline -n 50
 
           # Update REDMINE_LAST_SYNCED_COMMIT repo variable to the new synced commit


### PR DESCRIPTION
This PR fixes the following error in the sync-redmine workflow:
https://github.com/redmica/redmica/actions/runs/26424138467/job/77784368620
```
Applying: Enable parallel tests by default (redmine-44116).
Applying: Fix flaky IssueNestedSetConcurrencyTest (redmine-44116).
Applying: Fix flaky tests caused by locale leakage (redmine-44116).
Patch is empty.
```

To address this error, this PR changes the workflow to drop empty commits.